### PR TITLE
[TEMPLATE], don't merge: Unit testing sample for generateVmXML

### DIFF
--- a/opennebula/resource_opennebula_virtual_machine.go
+++ b/opennebula/resource_opennebula_virtual_machine.go
@@ -720,7 +720,12 @@ func waitForVmState(d *schema.ResourceData, meta interface{}, state string) (int
 	return stateConf.WaitForState()
 }
 
-func generateVmXML(d *schema.ResourceData) (string, error) {
+type ResourceData interface{
+	Get(key string) interface{}
+	GetOk(key string) (interface{}, bool)
+}
+
+func generateVmXML(d ResourceData) (string, error) {
 
 	//Generate CONTEXT definition
 	//context := d.Get("context").(*schema.Set).List()

--- a/opennebula/resource_opennebula_virtual_machine_test.go
+++ b/opennebula/resource_opennebula_virtual_machine_test.go
@@ -1,0 +1,90 @@
+package opennebula
+
+import (
+	"addon-terraform/opennebula/test"
+	"encoding/xml"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func UnsetVmResourceData() *test.StubResourceData {
+
+	// represents "unset" answers to Get/GetOk
+
+	testObj := new(test.StubResourceData)
+	testObj.
+		On("Get","cpu").
+			Return(0.0).
+		On("Get","vcpu").
+			Return(0).
+		On("Get", "memory").
+			Return(0).
+		On("Get", "context").
+			Return(make(map[string]interface{})).
+		On("Get","nic").
+			Return(&schema.Set{}).
+		On("Get", "disk").
+			Return(&schema.Set{}).
+		On("GetOk","graphics").
+			Return(&schema.Set{}, false).
+		On("GetOk","os").
+			Return(&schema.Set{}, false)
+
+	return testObj
+}
+
+func VmResourceDataWithCpuVcpuAndMem() *test.StubResourceData {
+
+	// represents answers to Get/GetOk with Cpu, VCpu and Memory set
+
+	testObj := new(test.StubResourceData)
+	testObj.
+		On("Get","cpu").
+			Return(0.8).
+		On("Get","vcpu").
+			Return(1).
+		On("Get", "memory").
+			Return(2048).
+		On("Get", "context").
+			Return(make(map[string]interface{})).
+		On("Get","nic").
+			Return(&schema.Set{}).
+		On("Get", "disk").
+			Return(&schema.Set{}).
+		On("GetOk","graphics").
+			Return(&schema.Set{}, false).
+		On("GetOk","os").
+			Return(&schema.Set{}, false)
+
+	return testObj
+}
+
+func TestGenerateXmlReturnsNilValuesForUnsetResourceData(t *testing.T) {
+
+	rd := UnsetVmResourceData()
+	vmTemplate := &vmTemplate{}
+
+	generatedXml, _ := generateVmXML(rd)
+	_ = xml.Unmarshal([]byte(generatedXml), vmTemplate)
+
+	rd.AssertExpectations(t)
+	assert.Equal(t, 0.0, vmTemplate.CPU)
+	assert.Equal(t, 0, vmTemplate.VCPU)
+	assert.Equal(t, 0, vmTemplate.Memory)
+}
+
+func TestGenerateXmlReturnsValuesForCpuVcpuAndMemSetInResourceData(t *testing.T) {
+
+	rd := VmResourceDataWithCpuVcpuAndMem()
+	vmTemplate := &vmTemplate{}
+
+	generatedXml, _ := generateVmXML(rd)
+	_ = xml.Unmarshal([]byte(generatedXml), vmTemplate)
+
+	rd.AssertExpectations(t)
+	assert.Equal(t, 0.8, vmTemplate.CPU)
+	assert.Equal(t, 1, vmTemplate.VCPU)
+	assert.Equal(t, 2048, vmTemplate.Memory)
+
+}

--- a/opennebula/test/resource_data.go
+++ b/opennebula/test/resource_data.go
@@ -1,0 +1,22 @@
+package test
+
+import "github.com/stretchr/testify/mock"
+
+// Provide stub implementation of Terraform's ResourceData
+// for unit testing
+
+// NOTE: This only stubs out methods actually used
+
+type StubResourceData struct {
+	mock.Mock
+}
+
+func (m *StubResourceData) Get(key string) interface{} {
+	args := m.Called(key)
+	return args.Get(0)
+}
+
+func (m *StubResourceData) GetOk(key string) (interface{}, bool) {
+	args := m.Called(key)
+	return args.Get(0), args.Bool(1)
+}


### PR DESCRIPTION
This PR is a draft to add unit-testability to `generateVmXML`. It tests the (broken) behaviour of current master and should not be merged. It could be integrated into #2 if the approach looks useful.